### PR TITLE
학습 관리 시스템 기능 정비

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,13 +13,12 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.OneBoard"
-        android:usesCleartextTraffic="true">
+        android:theme="@style/Theme.OneBoard">
         <activity
             android:name=".ui.SplashActivity"
+            android:exported="true"
             android:noHistory="true"
-            android:theme="@style/Theme.OneBoard.NoActionBar"
-            android:exported="true">
+            android:theme="@style/Theme.OneBoard.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/kr/khs/oneboard/adapters/LessonListAdapter.kt
+++ b/app/src/main/java/kr/khs/oneboard/adapters/LessonListAdapter.kt
@@ -39,10 +39,7 @@ class LessonListAdapter : ListAdapter<Lesson, RecyclerView.ViewHolder>(LessonDif
 
         fun bind(item: Lesson) {
             binding.item = item
-            item.note?.let {
-                binding.lessonNote.visibility = View.VISIBLE
-                binding.lessonNote.text = it
-            }
+            binding.lessonNote.text = if (item.noteUrl != null) "강의노트 등록 완료" else "강의노트 미등록"
             binding.lessonInfo.text = when (item.type) {
                 TYPE_NON_FACE_TO_FACE -> "비대면 실시간 수업"
                 TYPE_FACE_TO_FACE -> item.room ?: "아직 강의실이 정해지지 않았습니다."

--- a/app/src/main/java/kr/khs/oneboard/adapters/SubmitListAdapter.kt
+++ b/app/src/main/java/kr/khs/oneboard/adapters/SubmitListAdapter.kt
@@ -1,6 +1,9 @@
 package kr.khs.oneboard.adapters
 
 import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -9,6 +12,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import kr.khs.oneboard.data.Submit
 import kr.khs.oneboard.databinding.ListItemSubmitBinding
+import kr.khs.oneboard.utils.getFileUrl
 
 class SubmitListAdapter : ListAdapter<Submit, RecyclerView.ViewHolder>(SubmitDiffUtil()) {
 
@@ -16,7 +20,8 @@ class SubmitListAdapter : ListAdapter<Submit, RecyclerView.ViewHolder>(SubmitDif
 
     class SubmitViewHolder(
         private val binding: ListItemSubmitBinding,
-        private val listItemClickListener: (Submit) -> Unit
+        private val listItemClickListener: (Submit) -> Unit,
+        private val context: Context
     ) : RecyclerView.ViewHolder(binding.root) {
         init {
             binding.root.setOnClickListener {
@@ -29,7 +34,13 @@ class SubmitListAdapter : ListAdapter<Submit, RecyclerView.ViewHolder>(SubmitDif
         @SuppressLint("SetTextI18n")
         fun bind(item: Submit) {
             binding.item = item
-            item.fileUrl?.let { binding.submitFileUrl.text = it }
+            item.fileUrl?.let { fileUrl ->
+                binding.submitFileUrl.setOnClickListener {
+                    context.startActivity(
+                        Intent(Intent.ACTION_VIEW, Uri.parse(fileUrl.getFileUrl()))
+                    )
+                }
+            }
                 ?: run { binding.submitFileUrl.visibility = View.GONE }
             item.score?.let { binding.submitScore.text = String.format("* 점수 : %.1f", it) }
                 ?: run { binding.submitScore.visibility = View.GONE }
@@ -41,7 +52,8 @@ class SubmitListAdapter : ListAdapter<Submit, RecyclerView.ViewHolder>(SubmitDif
         companion object {
             fun from(
                 parent: ViewGroup,
-                listItemClickListener: (Submit) -> Unit
+                listItemClickListener: (Submit) -> Unit,
+                context: Context
             ): SubmitViewHolder {
                 return SubmitViewHolder(
                     ListItemSubmitBinding.inflate(
@@ -49,14 +61,19 @@ class SubmitListAdapter : ListAdapter<Submit, RecyclerView.ViewHolder>(SubmitDif
                         parent,
                         false
                     ),
-                    listItemClickListener
+                    listItemClickListener,
+                    context
                 )
             }
         }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        return SubmitListAdapter.SubmitViewHolder.from(parent, listItemClickListener)
+        return SubmitListAdapter.SubmitViewHolder.from(
+            parent,
+            listItemClickListener,
+            parent.context
+        )
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {

--- a/app/src/main/java/kr/khs/oneboard/api/ApiService.kt
+++ b/app/src/main/java/kr/khs/oneboard/api/ApiService.kt
@@ -3,7 +3,6 @@ package kr.khs.oneboard.api
 import kr.khs.oneboard.data.*
 import kr.khs.oneboard.data.api.BasicResponseImpl
 import kr.khs.oneboard.data.api.Response
-import kr.khs.oneboard.data.request.AssignmentUpdateRequestDto
 import kr.khs.oneboard.data.request.AttendanceUpdateRequestDto
 import kr.khs.oneboard.data.request.GradeUpdateRequestDto
 import kr.khs.oneboard.data.request.NoticeUpdateRequestDto
@@ -70,17 +69,21 @@ interface ApiService {
     @GET("lecture/{lectureId}/assignments")
     suspend fun getAssignmentList(@Path("lectureId") lectureId: Int): Response<List<Assignment>>
 
+    @Multipart
     @POST("lecture/{lectureId}/assignment")
     suspend fun postAssignment(
         @Path("lectureId") lectureId: Int,
-        @Body dto: AssignmentUpdateRequestDto
+        @Part file: MultipartBody.Part?,
+        @PartMap body: HashMap<String, RequestBody>
     ): BasicResponseImpl
 
+    @Multipart
     @PUT("lecture/{lectureId}/assignment/{assignmentId}")
     suspend fun putAssignment(
         @Path("lectureId") lectureId: Int,
         @Path("assignmentId") assignmentId: Int,
-        @Body dto: AssignmentUpdateRequestDto
+        @Part file: MultipartBody.Part?,
+        @PartMap body: HashMap<String, RequestBody>
     ): BasicResponseImpl
 
     @DELETE("lecture/{lectureId}/assignment/{assignmentId}")

--- a/app/src/main/java/kr/khs/oneboard/data/Assignment.kt
+++ b/app/src/main/java/kr/khs/oneboard/data/Assignment.kt
@@ -12,7 +12,7 @@ data class Assignment(
     override val content: String,
     override val exposeDt: String,
     override val updatedDt: String,
-    val fileUrl: String,
+    val fileUrl: String? = null,
     val startDt: String,
     val endDt: String,
     val score: Float

--- a/app/src/main/java/kr/khs/oneboard/data/GradeStudent.kt
+++ b/app/src/main/java/kr/khs/oneboard/data/GradeStudent.kt
@@ -19,7 +19,7 @@ data class GradeStudent(
         val submitId: Int,
         val assignmentId: Int,
         val assignmentTitle: String,
-        val score: Float
+        val score: Float? = null
     )
 }
 

--- a/app/src/main/java/kr/khs/oneboard/data/Lesson.kt
+++ b/app/src/main/java/kr/khs/oneboard/data/Lesson.kt
@@ -10,7 +10,7 @@ data class Lesson(
     val lectureId: Int,
     val title: String,
     val date: String,
-    val note: String? = null,
+    val noteUrl: String? = null,
     val type: Int,
     val room: String? = null,
     val meetingId: String? = null,

--- a/app/src/main/java/kr/khs/oneboard/repository/LectureRepository.kt
+++ b/app/src/main/java/kr/khs/oneboard/repository/LectureRepository.kt
@@ -5,6 +5,7 @@ import kr.khs.oneboard.data.*
 import kr.khs.oneboard.data.request.AssignmentUpdateRequestDto
 import kr.khs.oneboard.data.request.AttendanceUpdateRequestDto
 import kr.khs.oneboard.data.request.NoticeUpdateRequestDto
+import okhttp3.MultipartBody
 
 interface LectureRepository {
     suspend fun getDetailLecture(lectureId: Int): UseCase<Lecture>
@@ -25,13 +26,15 @@ interface LectureRepository {
 
     suspend fun postAssignment(
         lectureId: Int,
-        assignment: AssignmentUpdateRequestDto
+        assignment: AssignmentUpdateRequestDto,
+        file: MultipartBody.Part? = null
     ): UseCase<Boolean>
 
     suspend fun putAssignment(
         lectureId: Int,
         assignmentId: Int,
-        assignment: AssignmentUpdateRequestDto
+        assignment: AssignmentUpdateRequestDto,
+        file: MultipartBody.Part? = null
     ): UseCase<Boolean>
 
     suspend fun deleteAssignment(lectureId: Int, assignmentId: Int): UseCase<Boolean>

--- a/app/src/main/java/kr/khs/oneboard/repository/LectureRepositoryImpl.kt
+++ b/app/src/main/java/kr/khs/oneboard/repository/LectureRepositoryImpl.kt
@@ -11,6 +11,9 @@ import kr.khs.oneboard.data.request.AttendanceUpdateRequestDto
 import kr.khs.oneboard.data.request.GradeUpdateRequestDto
 import kr.khs.oneboard.data.request.NoticeUpdateRequestDto
 import kr.khs.oneboard.utils.SUCCESS
+import kr.khs.oneboard.utils.toPlainRequestBody
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Named
@@ -122,12 +125,22 @@ class LectureRepositoryImpl @Inject constructor(
 
     override suspend fun postAssignment(
         lectureId: Int,
-        assignment: AssignmentUpdateRequestDto
+        assignment: AssignmentUpdateRequestDto,
+        file: MultipartBody.Part?
     ): UseCase<Boolean> {
         var returnValue: UseCase<Boolean>
         try {
             withContext(Dispatchers.IO) {
-                val response = apiService.postAssignment(lectureId, assignment)
+                val map = HashMap<String, RequestBody>()
+                map["title"] = assignment.title.toPlainRequestBody()
+                map["content"] = assignment.content.toPlainRequestBody()
+                map["startDt"] = assignment.startDt.toPlainRequestBody()
+                map["endDt"] = assignment.endDt.toPlainRequestBody()
+                map["exposeDt"] = assignment.exposeDt.toPlainRequestBody()
+                map["score"] = assignment.score.toString().toPlainRequestBody()
+
+                val response = apiService.postAssignment(lectureId, file, map)
+
                 returnValue = if (response.result == SUCCESS)
                     UseCase.success(true)
                 else
@@ -144,12 +157,21 @@ class LectureRepositoryImpl @Inject constructor(
     override suspend fun putAssignment(
         lectureId: Int,
         assignmentId: Int,
-        assignment: AssignmentUpdateRequestDto
+        assignment: AssignmentUpdateRequestDto,
+        file: MultipartBody.Part?
     ): UseCase<Boolean> {
         var returnValue: UseCase<Boolean>
         try {
             withContext(Dispatchers.IO) {
-                val response = apiService.putAssignment(lectureId, assignmentId, assignment)
+                val map = HashMap<String, RequestBody>()
+                map["title"] = assignment.title.toPlainRequestBody()
+                map["content"] = assignment.content.toPlainRequestBody()
+                map["startDt"] = assignment.startDt.toPlainRequestBody()
+                map["endDt"] = assignment.endDt.toPlainRequestBody()
+                map["exposeDt"] = assignment.exposeDt.toPlainRequestBody()
+                map["score"] = assignment.score.toString().toPlainRequestBody()
+
+                val response = apiService.putAssignment(lectureId, assignmentId, file, map)
                 returnValue = if (response.result == SUCCESS)
                     UseCase.success(true)
                 else

--- a/app/src/main/java/kr/khs/oneboard/ui/AssignmentFragment.kt
+++ b/app/src/main/java/kr/khs/oneboard/ui/AssignmentFragment.kt
@@ -44,7 +44,7 @@ class AssignmentFragment : BaseFragment<FragmentAssignmentBinding, AssignmentVie
                 if (UserInfoUtil.type == TYPE_PROFESSOR)
                     it
                 else
-                    it.filter { it.exposeDt.toTimeInMillis() <= System.currentTimeMillis() }
+                    it.filter { it.exposeDt == "" || it.exposeDt.toTimeInMillis() <= System.currentTimeMillis() }
             )
         }
     }

--- a/app/src/main/java/kr/khs/oneboard/ui/AssignmentFragment.kt
+++ b/app/src/main/java/kr/khs/oneboard/ui/AssignmentFragment.kt
@@ -13,6 +13,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kr.khs.oneboard.adapters.AssignmentListAdapter
 import kr.khs.oneboard.core.BaseFragment
 import kr.khs.oneboard.databinding.FragmentAssignmentBinding
+import kr.khs.oneboard.extensions.toTimeInMillis
 import kr.khs.oneboard.utils.DialogUtil
 import kr.khs.oneboard.utils.TYPE_ASSIGNMENT
 import kr.khs.oneboard.utils.TYPE_PROFESSOR
@@ -39,7 +40,12 @@ class AssignmentFragment : BaseFragment<FragmentAssignmentBinding, AssignmentVie
         super.onViewCreated(view, savedInstanceState)
 
         viewModel.list.observe(viewLifecycleOwner) {
-            listAdapter.submitList(it)
+            listAdapter.submitList(
+                if (UserInfoUtil.type == TYPE_PROFESSOR)
+                    it
+                else
+                    it.filter { it.exposeDt.toTimeInMillis() <= System.currentTimeMillis() }
+            )
         }
     }
 

--- a/app/src/main/java/kr/khs/oneboard/ui/AssignmentFragment.kt
+++ b/app/src/main/java/kr/khs/oneboard/ui/AssignmentFragment.kt
@@ -107,12 +107,14 @@ class AssignmentFragment : BaseFragment<FragmentAssignmentBinding, AssignmentVie
                         "수정",
                         "삭제",
                         {
-                            AssignmentFragmentDirections.actionAssignmentFragmentToLectureWriteFragment(
-                                TYPE_ASSIGNMENT
-                            ).apply {
-                                isEdit = true
-                                assignment = item
-                            }
+                            findNavController().navigate(
+                                AssignmentFragmentDirections.actionAssignmentFragmentToLectureWriteFragment(
+                                    TYPE_ASSIGNMENT
+                                ).apply {
+                                    isEdit = true
+                                    assignment = item
+                                }
+                            )
                         },
                         { viewModel.deleteItem(parentViewModel.getLecture().id, item) },
                     )

--- a/app/src/main/java/kr/khs/oneboard/ui/ContentDetailFragment.kt
+++ b/app/src/main/java/kr/khs/oneboard/ui/ContentDetailFragment.kt
@@ -60,6 +60,10 @@ class ContentDetailFragment : BaseFragment<FragmentContentDetailBinding, Content
         binding.contentDetailContent.text = assignment.content
         binding.contentDetailDate.text = assignment.exposeDt
         binding.contentDetailAssignmentList.visibility = View.VISIBLE
+        assignment.fileUrl?.let {
+            binding.contentDetailFileUrl.visibility = View.VISIBLE
+            binding.contentDetailFileUrl.text = it
+        }
         initRecyclerView()
     }
 

--- a/app/src/main/java/kr/khs/oneboard/ui/ContentDetailFragment.kt
+++ b/app/src/main/java/kr/khs/oneboard/ui/ContentDetailFragment.kt
@@ -1,6 +1,10 @@
 package kr.khs.oneboard.ui
 
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
+import android.text.Html
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,6 +16,7 @@ import kr.khs.oneboard.adapters.SubmitListAdapter
 import kr.khs.oneboard.core.BaseFragment
 import kr.khs.oneboard.data.Assignment
 import kr.khs.oneboard.databinding.FragmentContentDetailBinding
+import kr.khs.oneboard.utils.getFileUrl
 import kr.khs.oneboard.viewmodels.ContentDetailViewModel
 
 @AndroidEntryPoint
@@ -55,14 +60,22 @@ class ContentDetailFragment : BaseFragment<FragmentContentDetailBinding, Content
         initViews()
     }
 
+    @SuppressLint("SetTextI18n")
     private fun initViews() {
         binding.contentDetailTitle.text = assignment.title
-        binding.contentDetailContent.text = assignment.content
+        binding.contentDetailContent.text =
+            Html.fromHtml(assignment.content, Html.FROM_HTML_MODE_LEGACY)
         binding.contentDetailDate.text = assignment.exposeDt
         binding.contentDetailAssignmentList.visibility = View.VISIBLE
-        assignment.fileUrl?.let {
+        assignment.fileUrl?.let { fileUrl ->
             binding.contentDetailFileUrl.visibility = View.VISIBLE
-            binding.contentDetailFileUrl.text = it
+            binding.contentDetailFileUrl.text = "${fileUrl.split("/").last()} 과제 파일 확인하기"
+
+            binding.contentDetailFileUrl.setOnClickListener {
+                startActivity(
+                    Intent(Intent.ACTION_VIEW, Uri.parse(fileUrl.getFileUrl()))
+                )
+            }
         }
         initRecyclerView()
     }

--- a/app/src/main/java/kr/khs/oneboard/ui/GradeProfessorFragment.kt
+++ b/app/src/main/java/kr/khs/oneboard/ui/GradeProfessorFragment.kt
@@ -49,6 +49,9 @@ class GradeProfessorFragment :
                         viewModel.setRatio(a = 0)
                     else if (a.toInt() > 100 || a.toInt() + b.toInt() > 100)
                         viewModel.setRatio(a = a.toInt() / 10)
+
+                    binding.gradeElseRatio.text =
+                        if (b == "") "100" else (100 - b.toInt() - a.toInt()).toString()
                 }
             }
         }
@@ -63,7 +66,7 @@ class GradeProfessorFragment :
                     }
 
                     binding.gradeElseRatio.text =
-                        if (b == "") "100" else (100 - b.toInt()).toString()
+                        if (b == "") "100" else (100 - b.toInt() - a.toInt()).toString()
                 }
             }
         }

--- a/app/src/main/java/kr/khs/oneboard/ui/LecturePlanFragment.kt
+++ b/app/src/main/java/kr/khs/oneboard/ui/LecturePlanFragment.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import kr.khs.oneboard.core.BaseFragment
 import kr.khs.oneboard.databinding.FragmentLecturePlanBinding
+import kr.khs.oneboard.utils.API_URL
 import kr.khs.oneboard.viewmodels.LecturePlanViewModel
 import timber.log.Timber
 
@@ -35,7 +36,7 @@ class LecturePlanFragment : BaseFragment<FragmentLecturePlanBinding, LecturePlan
     @SuppressLint("SetJavaScriptEnabled")
     override fun init() {
         val url =
-            "https://docs.google.com/gview?embedded=true&url=http://115.85.182.194:8080/lecture/${parentViewModel.getLecture().id}/plan"
+            "https://docs.google.com/gview?embedded=true&url=${API_URL}lecture/${parentViewModel.getLecture().id}/plan"
         Timber.tag("PlanUrl").d(url)
 
         if (url == "") goBackWhenError()

--- a/app/src/main/java/kr/khs/oneboard/ui/LectureReadFragment.kt
+++ b/app/src/main/java/kr/khs/oneboard/ui/LectureReadFragment.kt
@@ -107,7 +107,7 @@ class LectureReadFragment : BaseFragment<FragmentLectureReadBinding, LectureRead
             binding.readStartDT.text = item.startDt
             binding.readEndDT.visibility = View.VISIBLE
             binding.readEndDT.text = item.endDt
-            if (item.fileUrl != "") {
+            item.fileUrl?.let {
                 binding.readFileUrl.visibility = View.VISIBLE
                 binding.readFileUrl.text = item.fileUrl
             }

--- a/app/src/main/java/kr/khs/oneboard/ui/LectureReadFragment.kt
+++ b/app/src/main/java/kr/khs/oneboard/ui/LectureReadFragment.kt
@@ -42,10 +42,12 @@ class LectureReadFragment : BaseFragment<FragmentLectureReadBinding, LectureRead
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        viewModel.isSubmit.observe(viewLifecycleOwner) {
-            binding.readNoSubmitData.visibility = if (it) View.GONE else View.VISIBLE
-            if (it.not())
-                binding.readNoSubmitData.text = "과제를 제출하지 않았습니다."
+        viewModel.isSubmit.observe(viewLifecycleOwner) { isSubmit ->
+            assignment?.let {
+                binding.readNoSubmitData.visibility = if (isSubmit) View.GONE else View.VISIBLE
+                if (isSubmit.not())
+                    binding.readNoSubmitData.text = "과제를 제출하지 않았습니다."
+            }
         }
 
         viewModel.assignmentData.observe(viewLifecycleOwner) {

--- a/app/src/main/java/kr/khs/oneboard/ui/LectureReadFragment.kt
+++ b/app/src/main/java/kr/khs/oneboard/ui/LectureReadFragment.kt
@@ -14,6 +14,7 @@ import kr.khs.oneboard.data.Notice
 import kr.khs.oneboard.data.Submit
 import kr.khs.oneboard.databinding.FragmentLectureReadBinding
 import kr.khs.oneboard.databinding.ViewAssignmentDetailBinding
+import kr.khs.oneboard.utils.API_URL_WITHOUT_SLASH
 import kr.khs.oneboard.utils.TYPE_NOTICE
 import kr.khs.oneboard.utils.fileDownload
 import kr.khs.oneboard.viewmodels.LectureReadViewModel
@@ -76,7 +77,15 @@ class LectureReadFragment : BaseFragment<FragmentLectureReadBinding, LectureRead
             assignmentDetailContent.text = Html.fromHtml(item.content, Html.FROM_HTML_MODE_LEGACY)
 
             item.fileUrl?.let {
-                assignmentDetailFileUrl.text = it
+                assignmentDetailFileUrl.setOnClickListener {
+                    val fileName = "${item.assignmentTitle} 제출 과제.pdf"
+                    fileDownload(
+                        "과제 제출 파일 다운로드",
+                        "${item.assignmentTitle} 과제 파일",
+                        API_URL_WITHOUT_SLASH + item.fileUrl,
+                        fileName
+                    )
+                }
             } ?: run { assignmentDetailFileUrl.visibility = View.GONE }
         }
     }
@@ -116,7 +125,12 @@ class LectureReadFragment : BaseFragment<FragmentLectureReadBinding, LectureRead
                 binding.readFileUrl.text = fileName
                 binding.readFileDownloadBtn.visibility = View.VISIBLE
                 binding.readFileDownloadBtn.setOnClickListener {
-                    fileDownload("과제 다운로드", "${item.title} 과제 파일", item.fileUrl, fileName)
+                    fileDownload(
+                        "과제 다운로드",
+                        "${item.title} 과제 파일",
+                        API_URL_WITHOUT_SLASH + item.fileUrl,
+                        fileName
+                    )
                 }
             }
             binding.readContent.text = Html.fromHtml(item.content, Html.FROM_HTML_MODE_LEGACY)

--- a/app/src/main/java/kr/khs/oneboard/ui/LectureReadFragment.kt
+++ b/app/src/main/java/kr/khs/oneboard/ui/LectureReadFragment.kt
@@ -15,6 +15,7 @@ import kr.khs.oneboard.data.Submit
 import kr.khs.oneboard.databinding.FragmentLectureReadBinding
 import kr.khs.oneboard.databinding.ViewAssignmentDetailBinding
 import kr.khs.oneboard.utils.TYPE_NOTICE
+import kr.khs.oneboard.utils.fileDownload
 import kr.khs.oneboard.viewmodels.LectureReadViewModel
 import timber.log.Timber
 import kotlin.properties.Delegates
@@ -110,8 +111,13 @@ class LectureReadFragment : BaseFragment<FragmentLectureReadBinding, LectureRead
             binding.readEndDT.visibility = View.VISIBLE
             binding.readEndDT.text = item.endDt
             item.fileUrl?.let {
+                val fileName = "${item.title} 과제.pdf"
                 binding.readFileUrl.visibility = View.VISIBLE
-                binding.readFileUrl.text = item.fileUrl
+                binding.readFileUrl.text = fileName
+                binding.readFileDownloadBtn.visibility = View.VISIBLE
+                binding.readFileDownloadBtn.setOnClickListener {
+                    fileDownload("과제 다운로드", "${item.title} 과제 파일", item.fileUrl, fileName)
+                }
             }
             binding.readContent.text = Html.fromHtml(item.content, Html.FROM_HTML_MODE_LEGACY)
 

--- a/app/src/main/java/kr/khs/oneboard/ui/LectureWriteFragment.kt
+++ b/app/src/main/java/kr/khs/oneboard/ui/LectureWriteFragment.kt
@@ -154,6 +154,13 @@ class LectureWriteFragment : BaseFragment<FragmentLectureWriteBinding, LectureWr
             binding.writeEndDt.text = assignment?.endDt
             binding.writeAssignmentScore.setText(assignment?.score.toString())
         }
+
+        DialogUtil.createDialog(
+            requireContext(),
+            "파일 다시 업로드를 해주어야 합니다.",
+            positiveText = "알겠습니다.",
+            positiveAction = { }
+        )
     }
 
     private fun initExposeTime() {
@@ -233,6 +240,9 @@ class LectureWriteFragment : BaseFragment<FragmentLectureWriteBinding, LectureWr
                         ) {
                             viewModel.setErrorMessage("시작 시간이 마감 시간보다 크거나 같을 수 없습니다.")
                             return@setOnClickListener
+                        } else if (binding.writeAssignmentScore.text.toString().isEmpty()) {
+                            viewModel.setErrorMessage("배점을 입력해주세요.")
+                            return@setOnClickListener
                         }
                         AssignmentUpdateRequestDto(
                             binding.writeTitleEditText.text.toString(),
@@ -271,6 +281,9 @@ class LectureWriteFragment : BaseFragment<FragmentLectureWriteBinding, LectureWr
                                 .toTimeInMillis()
                         ) {
                             viewModel.setErrorMessage("시작 시간이 마감 시간보다 크거나 같을 수 없습니다.")
+                            return@setOnClickListener
+                        } else if (binding.writeAssignmentScore.text.toString().isEmpty()) {
+                            viewModel.setErrorMessage("배점을 입력해주세요.")
                             return@setOnClickListener
                         }
                         AssignmentUpdateRequestDto(

--- a/app/src/main/java/kr/khs/oneboard/ui/LectureWriteFragment.kt
+++ b/app/src/main/java/kr/khs/oneboard/ui/LectureWriteFragment.kt
@@ -21,10 +21,7 @@ import kr.khs.oneboard.data.request.NoticeUpdateRequestDto
 import kr.khs.oneboard.databinding.FragmentLectureWriteBinding
 import kr.khs.oneboard.extensions.toDateTime
 import kr.khs.oneboard.extensions.toTimeInMillis
-import kr.khs.oneboard.utils.TYPE_ASSIGNMENT
-import kr.khs.oneboard.utils.TYPE_NOTICE
-import kr.khs.oneboard.utils.ToastUtil
-import kr.khs.oneboard.utils.asMultipart
+import kr.khs.oneboard.utils.*
 import kr.khs.oneboard.viewmodels.LectureWriteViewModel
 import okhttp3.MultipartBody
 import timber.log.Timber
@@ -45,8 +42,9 @@ class LectureWriteFragment : BaseFragment<FragmentLectureWriteBinding, LectureWr
             if (result.resultCode == Activity.RESULT_OK) {
                 val data = result.data
                 assignmentFile =
-                    data?.data?.asMultipart("filename", requireContext().contentResolver)
-                binding.writeFileDescription.text = data?.data?.lastPathSegment
+                    data?.data?.asMultipart("file", requireContext().contentResolver)
+                binding.writeFileDescription.text =
+                    "${data?.data?.getFileName(requireContext().contentResolver)}"
             }
         }
 
@@ -249,7 +247,8 @@ class LectureWriteFragment : BaseFragment<FragmentLectureWriteBinding, LectureWr
                             binding.writeAssignmentScore.text.toString().toFloat()
                         )
                     } else
-                        null
+                        null,
+                    assignmentFile
                 )
             } else {
                 viewModel.writeContent(
@@ -287,7 +286,8 @@ class LectureWriteFragment : BaseFragment<FragmentLectureWriteBinding, LectureWr
                             binding.writeAssignmentScore.text.toString().toFloat()
                         )
                     } else
-                        null
+                        null,
+                    assignmentFile
                 )
             }
         }

--- a/app/src/main/java/kr/khs/oneboard/ui/LessonDetailFragment.kt
+++ b/app/src/main/java/kr/khs/oneboard/ui/LessonDetailFragment.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kr.khs.oneboard.core.BaseFragment
 import kr.khs.oneboard.data.Lesson
 import kr.khs.oneboard.databinding.FragmentLessonDetailBinding
+import kr.khs.oneboard.utils.API_URL
 import kr.khs.oneboard.utils.TYPE_FACE_TO_FACE
 import kr.khs.oneboard.utils.TYPE_NON_FACE_TO_FACE
 import kr.khs.oneboard.utils.TYPE_RECORDING
@@ -58,7 +59,7 @@ class LessonDetailFragment : BaseFragment<FragmentLessonDetailBinding, LessonDet
 
         with(binding.lessonDetailWebView) {
             val url =
-                "https://docs.google.com/gview?embedded=true&url=http://115.85.182.194:8080/lecture/${parentViewModel.getLecture().id}/lesson/${item.id}/note"
+                "https://docs.google.com/gview?embedded=true&url=${API_URL}lecture/${parentViewModel.getLecture().id}/lesson/${item.id}/note"
             webViewClient = WebViewClient() // 클릭 시 새창 안뜨게
             with(this.settings) {
                 javaScriptEnabled = true

--- a/app/src/main/java/kr/khs/oneboard/ui/LessonDetailFragment.kt
+++ b/app/src/main/java/kr/khs/oneboard/ui/LessonDetailFragment.kt
@@ -1,9 +1,5 @@
 package kr.khs.oneboard.ui
 
-import android.app.DownloadManager
-import android.content.Context
-import android.net.Uri
-import android.os.Environment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -13,10 +9,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kr.khs.oneboard.core.BaseFragment
 import kr.khs.oneboard.data.Lesson
 import kr.khs.oneboard.databinding.FragmentLessonDetailBinding
-import kr.khs.oneboard.utils.API_URL
-import kr.khs.oneboard.utils.TYPE_FACE_TO_FACE
-import kr.khs.oneboard.utils.TYPE_NON_FACE_TO_FACE
-import kr.khs.oneboard.utils.TYPE_RECORDING
+import kr.khs.oneboard.utils.*
 import kr.khs.oneboard.viewmodels.LessonDetailViewModel
 import timber.log.Timber
 
@@ -98,25 +91,7 @@ class LessonDetailFragment : BaseFragment<FragmentLessonDetailBinding, LessonDet
 
         binding.lessonDetailNoteDownloadBtn.setOnClickListener {
             val fileName = "${item.title} 강의노트.pdf"
-            fileDownload(downloadUrl, fileName)
+            fileDownload("$fileName 다운로드 ", "강의노트 다운로드", downloadUrl, fileName)
         }
-    }
-
-    private fun fileDownload(downloadUrl: String, fileName: String) {
-        val request = DownloadManager.Request(Uri.parse(downloadUrl))
-            .setTitle("$fileName 다운로드 ")
-            .setDescription("강의노트 다운로드")
-            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-            .setDestinationInExternalPublicDir(
-                Environment.DIRECTORY_DOWNLOADS,
-                fileName
-            )
-            .setRequiresCharging(false)
-            .setAllowedOverMetered(true)
-            .setAllowedOverRoaming(true)
-
-        (requireContext().getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager).enqueue(
-            request
-        )
     }
 }

--- a/app/src/main/java/kr/khs/oneboard/ui/LessonListFragment.kt
+++ b/app/src/main/java/kr/khs/oneboard/ui/LessonListFragment.kt
@@ -68,7 +68,6 @@ class LessonListFragment : BaseFragment<FragmentLessonListBinding, LessonListVie
         })
 
         binding.fab.setOnClickListener {
-            // TODO: 2021/11/01 add lesson
             findNavController().navigate(LessonListFragmentDirections.actionLessonListFragmentToLessonWriteFragment())
         }
     }

--- a/app/src/main/java/kr/khs/oneboard/ui/MainActivity.kt
+++ b/app/src/main/java/kr/khs/oneboard/ui/MainActivity.kt
@@ -21,7 +21,6 @@ import kr.khs.oneboard.utils.*
 import kr.khs.oneboard.viewmodels.MainViewModel
 import timber.log.Timber
 
-// todo : return value 간단하게 할 수 있는 것은 = 사용해서 바꿔주기
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     private val binding: ActivityMainBinding by lazy {
@@ -210,7 +209,4 @@ class MainActivity : AppCompatActivity() {
     }
 }
 
-// TODO: 2021/11/19 학생, 강의자 모든 화면 구분해주기
-// TODO: 2021/11/19 수업 관련
-// TODO: 2021/11/19 HTML 
-// TODO: 2021/11/19 pdf 뷰어, 파일 다운로드 찾아보기 
+// TODO: 2021/11/19 파일 다운로드 찾아보기

--- a/app/src/main/java/kr/khs/oneboard/ui/NoticeFragment.kt
+++ b/app/src/main/java/kr/khs/oneboard/ui/NoticeFragment.kt
@@ -13,6 +13,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kr.khs.oneboard.adapters.NoticeListAdapter
 import kr.khs.oneboard.core.BaseFragment
 import kr.khs.oneboard.databinding.FragmentNoticeBinding
+import kr.khs.oneboard.extensions.toTimeInMillis
 import kr.khs.oneboard.utils.DialogUtil
 import kr.khs.oneboard.utils.TYPE_NOTICE
 import kr.khs.oneboard.utils.TYPE_PROFESSOR
@@ -40,7 +41,10 @@ class NoticeFragment : BaseFragment<FragmentNoticeBinding, NoticeViewModel>() {
 
         viewModel.list.observe(viewLifecycleOwner) {
             listAdapter.submitList(
-                it
+                if (UserInfoUtil.type == TYPE_PROFESSOR)
+                    it
+                else
+                    it.filter { it.exposeDt.toTimeInMillis() <= System.currentTimeMillis() }
             )
         }
     }

--- a/app/src/main/java/kr/khs/oneboard/utils/Constants.kt
+++ b/app/src/main/java/kr/khs/oneboard/utils/Constants.kt
@@ -1,6 +1,6 @@
 package kr.khs.oneboard.utils
 
-const val API_URL = "https://115.85.182.194:8080/"
+const val API_URL = "https://oneboard.connect.o-r.kr:8080/"
 
 const val SUCCESS = "SUCCESS"
 const val FAIL = "FAIL"

--- a/app/src/main/java/kr/khs/oneboard/utils/Constants.kt
+++ b/app/src/main/java/kr/khs/oneboard/utils/Constants.kt
@@ -1,6 +1,6 @@
 package kr.khs.oneboard.utils
 
-const val API_URL = "http://115.85.182.194:8080/"
+const val API_URL = "https//115.85.182.194:8080/"
 
 const val SUCCESS = "SUCCESS"
 const val FAIL = "FAIL"

--- a/app/src/main/java/kr/khs/oneboard/utils/Constants.kt
+++ b/app/src/main/java/kr/khs/oneboard/utils/Constants.kt
@@ -1,6 +1,6 @@
 package kr.khs.oneboard.utils
 
-const val API_URL = "https//115.85.182.194:8080/"
+const val API_URL = "https://115.85.182.194:8080/"
 
 const val SUCCESS = "SUCCESS"
 const val FAIL = "FAIL"

--- a/app/src/main/java/kr/khs/oneboard/utils/Constants.kt
+++ b/app/src/main/java/kr/khs/oneboard/utils/Constants.kt
@@ -1,6 +1,7 @@
 package kr.khs.oneboard.utils
 
 const val API_URL = "https://oneboard.connect.o-r.kr:8080/"
+const val API_URL_WITHOUT_SLASH = "https://oneboard.connect.o-r.kr:8080"
 
 const val SUCCESS = "SUCCESS"
 const val FAIL = "FAIL"

--- a/app/src/main/java/kr/khs/oneboard/utils/FileUtil.kt
+++ b/app/src/main/java/kr/khs/oneboard/utils/FileUtil.kt
@@ -83,3 +83,6 @@ fun Fragment.fileDownload(
         request
     )
 }
+
+fun String.getFileUrl() =
+    "https://docs.google.com/gview?embedded=true&url=${API_URL_WITHOUT_SLASH}$this"

--- a/app/src/main/java/kr/khs/oneboard/utils/FileUtil.kt
+++ b/app/src/main/java/kr/khs/oneboard/utils/FileUtil.kt
@@ -1,10 +1,14 @@
 package kr.khs.oneboard.utils
 
 import android.annotation.SuppressLint
+import android.app.DownloadManager
 import android.content.ContentResolver
+import android.content.Context
 import android.database.Cursor
 import android.net.Uri
+import android.os.Environment
 import android.provider.OpenableColumns
+import androidx.fragment.app.Fragment
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
@@ -55,4 +59,27 @@ fun Uri.getFileName(contentResolver: ContentResolver): String {
         result = this.lastPathSegment
     }
     return result ?: "nullll"
+}
+
+fun Fragment.fileDownload(
+    title: String,
+    description: String,
+    downloadUrl: String,
+    fileName: String
+) {
+    val request = DownloadManager.Request(Uri.parse(downloadUrl))
+        .setTitle(title)
+        .setDescription(description)
+        .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+        .setDestinationInExternalPublicDir(
+            Environment.DIRECTORY_DOWNLOADS,
+            fileName
+        )
+        .setRequiresCharging(false)
+        .setAllowedOverMetered(true)
+        .setAllowedOverRoaming(true)
+
+    (requireContext().getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager).enqueue(
+        request
+    )
 }

--- a/app/src/main/java/kr/khs/oneboard/viewmodels/LectureWriteViewModel.kt
+++ b/app/src/main/java/kr/khs/oneboard/viewmodels/LectureWriteViewModel.kt
@@ -11,6 +11,7 @@ import kr.khs.oneboard.data.request.NoticeUpdateRequestDto
 import kr.khs.oneboard.repository.LectureRepository
 import kr.khs.oneboard.utils.TYPE_ASSIGNMENT
 import kr.khs.oneboard.utils.TYPE_NOTICE
+import okhttp3.MultipartBody
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -24,7 +25,8 @@ class LectureWriteViewModel @Inject constructor(private val repository: LectureR
         contentId: Int,
         type: Boolean,
         notice: NoticeUpdateRequestDto? = null,
-        assignment: AssignmentUpdateRequestDto? = null
+        assignment: AssignmentUpdateRequestDto? = null,
+        file: MultipartBody.Part? = null
     ) {
         if (contentId == -1) {
             setErrorMessage("올바르지 않은 접근입니다.")
@@ -38,7 +40,7 @@ class LectureWriteViewModel @Inject constructor(private val repository: LectureR
                     repository.putNotice(lectureId, contentId, notice!!)
                 }
                 TYPE_ASSIGNMENT -> {
-                    repository.putAssignment(lectureId, contentId, assignment!!)
+                    repository.putAssignment(lectureId, contentId, assignment!!, file)
                 }
                 else -> throw Exception("Unknown Type")
             }
@@ -51,9 +53,11 @@ class LectureWriteViewModel @Inject constructor(private val repository: LectureR
         lectureId: Int,
         type: Boolean,
         notice: NoticeUpdateRequestDto? = null,
-        assignment: AssignmentUpdateRequestDto? = null
+        assignment: AssignmentUpdateRequestDto? = null,
+        file: MultipartBody.Part? = null
     ) {
         var result: UseCase<Boolean>
+        Timber.tag("WriteAssignment").d("file is null : ${file == null}")
         viewModelScope.launch {
             showProgress()
             result = when (type) {
@@ -63,7 +67,7 @@ class LectureWriteViewModel @Inject constructor(private val repository: LectureR
                 }
                 TYPE_ASSIGNMENT -> {
                     Timber.tag("Write").d("$assignment")
-                    repository.postAssignment(lectureId, assignment!!)
+                    repository.postAssignment(lectureId, assignment!!, file)
                 }
                 else -> throw Exception("Unknown Type")
             }

--- a/app/src/main/java/kr/khs/oneboard/views/ThreeStateCheckBox.kt
+++ b/app/src/main/java/kr/khs/oneboard/views/ThreeStateCheckBox.kt
@@ -25,8 +25,6 @@ class ThreeStateCheckBox @JvmOverloads constructor(
         attrs?.let {
             val typedArray = context.obtainStyledAttributes(attrs, R.styleable.ThreeStateCheckBox)
 
-            state = typedArray.getInt(R.styleable.ThreeStateCheckBox_state, STATE_UNCHECKED)
-
             textUnchecked =
                 typedArray.getString(R.styleable.ThreeStateCheckBox_text_state_unchecked)
             textIndeterminate =
@@ -34,17 +32,12 @@ class ThreeStateCheckBox @JvmOverloads constructor(
             textChecked = typedArray.getString(R.styleable.ThreeStateCheckBox_text_state_checked)
             isClickable = typedArray.getBoolean(R.styleable.ThreeStateCheckBox_clickable, false)
 
+            typedArray.recycle()
+
             changeText(state)
             changeDrawable(state)
 
-            Timber.d("state: $state")
-            Timber.d("textUnChecked : $textUnchecked")
-            Timber.d("textIndeterminate: $textIndeterminate")
-            Timber.d("textChecked : $textChecked")
-
-            typedArray.recycle()
-
-//            initComponent()
+            initComponent()
         }
     }
 
@@ -72,17 +65,18 @@ class ThreeStateCheckBox @JvmOverloads constructor(
 
     var onStateChanged: ((ThreeStateCheckBox, Int) -> Unit)? = null
 
-//    private fun initComponent() {
-//        Timber.d("initComponent()")
-//        setOnCheckedChangeListener { _, _ ->
-//            state = when (state) {
-//                STATE_UNCHECKED -> STATE_CHECKED
-//                STATE_CHECKED -> STATE_INDETERMINATE
-//                STATE_INDETERMINATE -> STATE_UNCHECKED
-//                else -> -1
-//            }
-//        }
-//    }
+    private fun initComponent() {
+        Timber.d("initComponent()")
+        setOnClickListener { _ ->
+            Timber.d("checkChange")
+            state = when (state) {
+                STATE_UNCHECKED -> STATE_CHECKED
+                STATE_CHECKED -> STATE_INDETERMINATE
+                STATE_INDETERMINATE -> STATE_UNCHECKED
+                else -> -1
+            }
+        }
+    }
 
     private fun changeText(state: Int) {
         text = when (state) {

--- a/app/src/main/res/layout/fragment_content_detail.xml
+++ b/app/src/main/res/layout/fragment_content_detail.xml
@@ -44,9 +44,32 @@
         android:id="@+id/contentDetailAssignmentList"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_marginTop="16dp"
+        android:layout_marginTop="8dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="@+id/contentDetailDate"
         app:layout_constraintStart_toStartOf="@+id/contentDetailTitle"
-        app:layout_constraintTop_toBottomOf="@+id/contentDetailContent" />
+        app:layout_constraintTop_toBottomOf="@+id/textView2" />
+
+    <TextView
+        android:id="@+id/contentDetailFileUrl"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:visibility="gone"
+        android:textColor="@color/black"
+        app:layout_constraintEnd_toEndOf="@+id/contentDetailDate"
+        app:layout_constraintStart_toStartOf="@+id/contentDetailContent"
+        app:layout_constraintTop_toBottomOf="@+id/contentDetailContent"
+        tools:visibility="visible"
+        tools:text="파일 url" />
+
+    <TextView
+        android:id="@+id/textView2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:textColor="@color/black"
+        android:text="제출 학생 목록"
+        app:layout_constraintStart_toStartOf="@+id/contentDetailFileUrl"
+        app:layout_constraintTop_toBottomOf="@+id/contentDetailFileUrl" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_content_detail.xml
+++ b/app/src/main/res/layout/fragment_content_detail.xml
@@ -55,13 +55,13 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
+        android:textColor="@android:color/holo_blue_bright"
         android:visibility="gone"
-        android:textColor="@color/black"
         app:layout_constraintEnd_toEndOf="@+id/contentDetailDate"
         app:layout_constraintStart_toStartOf="@+id/contentDetailContent"
         app:layout_constraintTop_toBottomOf="@+id/contentDetailContent"
-        tools:visibility="visible"
-        tools:text="파일 url" />
+        tools:text="파일 url"
+        tools:visibility="visible" />
 
     <TextView
         android:id="@+id/textView2"

--- a/app/src/main/res/layout/fragment_lecture_read.xml
+++ b/app/src/main/res/layout/fragment_lecture_read.xml
@@ -53,7 +53,8 @@
         app:layout_constraintEnd_toStartOf="@+id/guideline2"
         app:layout_constraintStart_toStartOf="@+id/readTitle"
         app:layout_constraintTop_toBottomOf="@+id/readTitle"
-        tools:text="시작 시간" />
+        tools:text="시작 시간"
+        tools:visibility="visible" />
 
     <TextView
         android:id="@+id/readEndDT"
@@ -69,7 +70,8 @@
         app:layout_constraintEnd_toEndOf="@+id/readTime"
         app:layout_constraintStart_toStartOf="@+id/guideline2"
         app:layout_constraintTop_toTopOf="@+id/readStartDT"
-        tools:text="마감 시간" />
+        tools:text="마감 시간"
+        tools:visibility="visible" />
 
     <TextView
         android:id="@+id/readContent"
@@ -91,15 +93,18 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
         android:background="@drawable/round_corner"
         android:backgroundTint="@color/primaryLightColor"
         android:padding="8dp"
         android:textColor="@color/black"
         android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="@+id/readTime"
+        app:layout_constraintEnd_toStartOf="@+id/readFileDownloadBtn"
         app:layout_constraintStart_toStartOf="@+id/readTitle"
         app:layout_constraintTop_toBottomOf="@+id/readStartDT"
-        tools:text="파일" />
+        tools:text="파일"
+        tools:visibility="visible" />
+
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline2"
@@ -129,4 +134,16 @@
         app:layout_constraintEnd_toEndOf="@+id/readTime"
         app:layout_constraintStart_toStartOf="@+id/readTitle"
         app:layout_constraintTop_toBottomOf="@+id/readContent" />
+
+    <Button
+        android:id="@+id/readFileDownloadBtn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="다운로드"
+        android:textColor="@color/white"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@+id/readFileUrl"
+        app:layout_constraintEnd_toEndOf="@+id/readEndDT"
+        app:layout_constraintTop_toTopOf="@+id/readFileUrl"
+        tools:visibility="visible" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_lecture_read.xml
+++ b/app/src/main/res/layout/fragment_lecture_read.xml
@@ -130,6 +130,7 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginTop="16dp"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="@+id/readTime"
         app:layout_constraintStart_toStartOf="@+id/readTitle"

--- a/app/src/main/res/layout/fragment_lesson_detail.xml
+++ b/app/src/main/res/layout/fragment_lesson_detail.xml
@@ -45,9 +45,10 @@
         android:id="@+id/lessonDetailPlanUrl"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
         android:text="강의노트 보기"
         android:textColor="@color/black"
-        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toBottomOf="@+id/lessonDetailNoteDownloadBtn"
         app:layout_constraintStart_toStartOf="@+id/lessonDetailInfo"
         app:layout_constraintTop_toBottomOf="@+id/lessonDetailLessonBtn"
         tools:text="강의 노트 보기" />
@@ -56,10 +57,11 @@
         android:id="@+id/lessonDetailWebView"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:layout_marginTop="8dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/lessonDetailPlanUrl" />
+        app:layout_constraintTop_toBottomOf="@+id/lessonDetailNoteDownloadBtn" />
 
     <Button
         android:id="@+id/lessonDetailLessonBtn"
@@ -70,6 +72,15 @@
         android:textColor="#FFFFFF"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/lessonDetailDate" />
+
+    <Button
+        android:id="@+id/lessonDetailNoteDownloadBtn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="다운로드"
+        android:textColor="@color/white"
+        app:layout_constraintEnd_toEndOf="@+id/lessonDetailLessonBtn"
+        app:layout_constraintTop_toBottomOf="@+id/lessonDetailLessonBtn" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/list_item_attendance_lesson.xml
+++ b/app/src/main/res/layout/list_item_attendance_lesson.xml
@@ -14,9 +14,9 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingVertical="16dp"
+        android:background="@drawable/round_corner"
         android:paddingHorizontal="8dp"
-        android:background="@drawable/round_corner">
+        android:paddingVertical="16dp">
 
         <TextView
             android:id="@+id/attendanceLessonDate"
@@ -40,6 +40,7 @@
             app:layout_constraintBottom_toBottomOf="@+id/attendanceLessonDate"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@+id/attendanceLessonDate"
+            app:state="@{item.status}"
             app:text_state_checked="출석"
             app:text_state_indeterminate="지각"
             app:text_state_unchecked="결석"

--- a/app/src/main/res/layout/list_item_lesson.xml
+++ b/app/src/main/res/layout/list_item_lesson.xml
@@ -41,10 +41,12 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:text="날짜" />
 
-        <ImageView
+        <ImageButton
             android:id="@+id/lessonOption"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@null"
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
@@ -55,8 +57,8 @@
             android:id="@+id/lessonInfo"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="@color/black"
             android:layout_marginTop="8dp"
+            android:textColor="@color/black"
             app:layout_constraintEnd_toEndOf="@id/lessonTitle"
             app:layout_constraintStart_toStartOf="@id/lessonTitle"
             app:layout_constraintTop_toBottomOf="@id/lessonTitle"
@@ -67,9 +69,9 @@
             android:id="@+id/lessonNote"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
             android:textColor="@color/black"
             android:visibility="gone"
-            android:layout_marginTop="8dp"
             app:layout_constraintEnd_toEndOf="@id/lessonTitle"
             app:layout_constraintStart_toStartOf="@id/lessonTitle"
             app:layout_constraintTop_toBottomOf="@id/lessonInfo"

--- a/app/src/main/res/layout/list_item_lesson.xml
+++ b/app/src/main/res/layout/list_item_lesson.xml
@@ -71,11 +71,9 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:textColor="@color/black"
-            android:visibility="gone"
             app:layout_constraintEnd_toEndOf="@id/lessonTitle"
             app:layout_constraintStart_toStartOf="@id/lessonTitle"
             app:layout_constraintTop_toBottomOf="@id/lessonInfo"
-            tools:text="강의 노트 주소"
-            tools:visibility="visible" />
+            tools:text="강의 노트 등록 여부" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/list_item_submit.xml
+++ b/app/src/main/res/layout/list_item_submit.xml
@@ -40,11 +40,11 @@
             android:id="@+id/submitFileUrl"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="@color/black"
             android:padding="4dp"
+            android:text="제출 파일 확인하기"
+            android:textColor="@android:color/holo_blue_bright"
             app:layout_constraintStart_toStartOf="@+id/submitStudentName"
-            app:layout_constraintTop_toBottomOf="@+id/submitStudentName"
-            tools:text="https://naver.com" />
+            app:layout_constraintTop_toBottomOf="@+id/submitStudentName" />
 
         <TextView
             android:id="@+id/submitContent"

--- a/app/src/main/res/layout/list_item_submit_grade.xml
+++ b/app/src/main/res/layout/list_item_submit_grade.xml
@@ -13,8 +13,8 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingVertical="16dp"
-        android:paddingHorizontal="8dp">
+        android:paddingHorizontal="8dp"
+        android:paddingVertical="16dp">
 
         <TextView
             android:id="@+id/listItemGradeTitle"
@@ -24,8 +24,8 @@
             android:layout_marginTop="8dp"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="8dp"
-            android:textColor="#000000"
             android:text="@{item.assignmentTitle}"
+            android:textColor="#000000"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/listItemGradeScore"
             app:layout_constraintStart_toStartOf="parent"
@@ -37,8 +37,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="8dp"
+            android:text='@{item.score != null ? String.valueOf(item.score) : "채점 안됨."}'
             android:textColor="#000000"
-            android:text="@{String.valueOf(item.score)}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/view_assignment_detail.xml
+++ b/app/src/main/res/layout/view_assignment_detail.xml
@@ -10,6 +10,15 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
+        <View
+            android:id="@+id/view"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:background="@android:color/darker_gray"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <TextView
             android:id="@+id/assignmentDetailScore"
             android:layout_width="wrap_content"
@@ -55,19 +64,19 @@
             android:textColor="#000000"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/view"
             tools:text="이번주 과제 제출 입니다.\n1번 답 : int main()\n2번 답 : { printf(1);\n3번 답 : return 0; }" />
 
-        <TextView
+        <Button
             android:id="@+id/assignmentDetailFileUrl"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:padding="8dp"
-            android:textColor="#000000"
+            android:text="제출한 파일 다운로드"
+            android:textColor="@color/white"
             app:layout_constraintStart_toStartOf="@+id/assignmentDetailContent"
             app:layout_constraintTop_toBottomOf="@+id/assignmentDetailContent"
-            tools:text="https://naver.com"
             tools:visibility="visible" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,13 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <attr name="state" format="enum">
-        <enum name="unchecked" value="0" />
-        <enum name="indeterminate" value="1" />
-        <enum name="checked" value="2" />
-    </attr>
-
     <declare-styleable name="ThreeStateCheckBox">
-        <attr name="state" />
         <attr name="text_state_unchecked" format="string" />
         <attr name="text_state_indeterminate" format="string" />
         <attr name="text_state_checked" format="string" />


### PR DESCRIPTION
- `API URL` 변경 : Https 프로토콜 적용 및 도메인 주소 사용
- `Assignment` 데이터 클래스의 `fileUrl` nullable하게 변경 및 기본 값 적용
- `Lesson` 데이터 클래스 프로퍼티 명 변경 : `note` ➡️ `noteUrl`
-  성적 비율 오류 수정 : (100 - `A Ratio` - `B Ratio`)
- 구글 독스를 사용하여 웹 뷰로 문서를 볼 때 `URL` 경로 수정
- `DownloadManager`를 통한 파일 다운로드 기능
</br>

- [x] 강의 노트 다운로드 기능
- [x] 과제 등록, 수정 api `Multipart` 적용
- [x] 과제 파일(과제를 생성할 때 등록하는 파일) 다운로드 기능
- [x] 강의자가 `과제 목록`에서 과제를 클릭했을 경우, 과제 게시글과 제출한 학생의 목록이 나타난다. 이 때 파일 클릭 시, 웹으로 넘어가 파일 미리보기 기능 구현
</br>

**오류 수정**
- #6  수정
> 1. 기존에는 `setOnCheckedChangeListener`로 `STATE_UNCHECKED(0)`, `STATE_INDETERMINATE(1)`, `STATE_CHECKED(2)` 관리를 해줬었음.
> 2. `0 -> 2`, `1 -> 0`로 변경될 때, `isChecked`의 값이 변경되므로 `onCheckedChangeListener`에 의해 값이 한 번 더 변경되는 상황 발생
> 3. `isChecked`의 변경은 `state`의 setter에서 진행해줌.
> 4. 2, 3이 충돌하여 문제 발생
> 5. `setOnCheckedChangeListener`을 `setOnClickListener`로 변경하여 문제 해결